### PR TITLE
Fix #75: Certain blocks [e.g. cables] get superfluous NBT from inventory charger and don't stack

### DIFF
--- a/common/src/main/java/owmii/powah/block/ender/AbstractEnderTile.java
+++ b/common/src/main/java/owmii/powah/block/ender/AbstractEnderTile.java
@@ -47,7 +47,7 @@ public class AbstractEnderTile<B extends AbstractEnergyBlock<EnderConfig, B>> ex
 
     @Override
     public CompoundTag writeStorable(CompoundTag nbt) {
-        this.channel.writ(nbt, "channel");
+        this.channel.write(nbt, "channel");
         if (this.owner != null) {
             nbt.putUUID("owner_id", this.owner.getId());
             nbt.putString("owner_name", this.owner.getName());

--- a/common/src/main/java/owmii/powah/lib/util/math/RangedInt.java
+++ b/common/src/main/java/owmii/powah/lib/util/math/RangedInt.java
@@ -29,7 +29,7 @@ public class RangedInt {
         return this;
     }
 
-    public CompoundTag writ(CompoundTag nbt, String key) {
+    public CompoundTag write(CompoundTag nbt, String key) {
         nbt.putInt(key, this.value);
         return nbt;
     }

--- a/forge/src/main/java/owmii/powah/forge/ForgeEnvHandler.java
+++ b/forge/src/main/java/owmii/powah/forge/ForgeEnvHandler.java
@@ -218,11 +218,17 @@ public class ForgeEnvHandler implements EnvHandler {
 									return new IEnergyStorage() {
 										@Override
 										public int receiveEnergy(int i, boolean bl) {
+											if (info.capacity() == 0 || !energyItem.canReceive()) {
+												return 0;
+											}
 											return Ints.saturatedCast(energyItem.receiveEnergy(i, bl));
 										}
 
 										@Override
 										public int extractEnergy(int i, boolean bl) {
+											if (!energyItem.canExtract()) {
+												return 0;
+											}
 											return Ints.saturatedCast(energyItem.extractEnergy(i, bl));
 										}
 


### PR DESCRIPTION
Check canReceive/canExtract before trying to insert/extract (will save the tag to item even if charged amount is 0)

Also check for 0 capacity on insert, since canReceive/isFull will return true/false for 0 capacity