### PR TITLE
Abort building reactor if a block is placed in a space we are trying to place a reactor block

### DIFF
--- a/common/src/main/java/owmii/powah/block/reactor/Builder.java
+++ b/common/src/main/java/owmii/powah/block/reactor/Builder.java
@@ -51,6 +51,13 @@ public class Builder {
                 while (itr.hasNext()) {
                     BlockPos pos = itr.next();
                     BlockState state = this.reactor.getBlock().defaultBlockState();
+                    if (!world.getBlockState(pos).getMaterial().isReplaceable()) {
+                        final List<BlockPos> placed = new ArrayList<>(this.getPosList());
+                        placed.removeAll(this.queue);
+                        placed.forEach(b -> world.destroyBlock(b, true));
+                        world.destroyBlock(this.reactor.getBlockPos(), true);
+                        return false;
+                    }
                     world.setBlock(pos, state.setValue(ReactorBlock.CORE, false), 3);
                     BlockEntity tileEntity = world.getBlockEntity(pos);
                     if (tileEntity instanceof ReactorPartTile) {

--- a/common/src/main/java/owmii/powah/block/reactor/Builder.java
+++ b/common/src/main/java/owmii/powah/block/reactor/Builder.java
@@ -52,10 +52,7 @@ public class Builder {
                     BlockPos pos = itr.next();
                     BlockState state = this.reactor.getBlock().defaultBlockState();
                     if (!world.getBlockState(pos).getMaterial().isReplaceable()) {
-                        final List<BlockPos> placed = new ArrayList<>(this.getPosList());
-                        placed.removeAll(this.queue);
-                        placed.forEach(b -> world.destroyBlock(b, true));
-                        world.destroyBlock(this.reactor.getBlockPos(), true);
+                        this.demolish(world);
                         return false;
                     }
                     world.setBlock(pos, state.setValue(ReactorBlock.CORE, false), 3);
@@ -102,6 +99,7 @@ public class Builder {
     public void demolish(Level world) {
         List<BlockPos> list = getPosList();
         list.add(this.reactor.getBlockPos());
+        list.removeAll(this.queue);
         int count = 0;
         for (BlockPos blockPos : list) {
             if (world.getBlockState(blockPos).getBlock().equals(this.reactor.getBlock())) {


### PR DESCRIPTION
Prevents having two reactors intersect each other if you place them quickly with a one block gap between

Also stops it from eating any other blocks placed in air that it wants to replace