### PR TITLE
Correct lighting checks for solar panels to support modded dimensions

### DIFF
--- a/common/src/main/java/owmii/powah/block/solar/SolarTile.java
+++ b/common/src/main/java/owmii/powah/block/solar/SolarTile.java
@@ -59,7 +59,7 @@ public class SolarTile extends AbstractEnergyProvider<SolarBlock> implements IIn
                 }
             }
             if (!this.energy.isFull()) {
-                if ((this.canSeeSky || this.hasLensOfEnder) && (!world.dimensionType().hasSkyLight() || world.getSkyDarken() >= 4)) {
+                if ((this.canSeeSky || this.hasLensOfEnder) && (world.dimensionType().hasSkyLight() && world.getSkyDarken() < 4) {
                     this.energy.produce(getGeneration());
                     flag = true;
                 }

--- a/common/src/main/java/owmii/powah/block/solar/SolarTile.java
+++ b/common/src/main/java/owmii/powah/block/solar/SolarTile.java
@@ -59,7 +59,7 @@ public class SolarTile extends AbstractEnergyProvider<SolarBlock> implements IIn
                 }
             }
             if (!this.energy.isFull()) {
-                if ((this.canSeeSky || this.hasLensOfEnder) && world.isDay()) {
+                if ((this.canSeeSky || this.hasLensOfEnder) && (!world.dimensionType().hasSkyLight() || world.getSkyDarken() >= 4)) {
                     this.energy.produce(getGeneration());
                     flag = true;
                 }


### PR DESCRIPTION
The isDay basic check doesn't work for many modded dimensions, specifically those with static time like mining dimensions. Changing this line will allow for the solar panels to continue working during normal light hours in dimensions with nonstandard days or nonstandard skylights