### PR TITLE
Fix for silk touching ores not dropping the ore blocks

### DIFF
--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:deepslate_uraninite_ore"
             },
             {
               "type": "minecraft:item",

--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore_dense.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore_dense.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:deepslate_uraninite_ore_dense"
             },
             {
               "type": "minecraft:item",

--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore_poor.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/deepslate_uraninite_ore_poor.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:deepslate_uraninite_ore_poor"
             },
             {
               "type": "minecraft:item",

--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:uraninite_ore"
             },
             {
               "type": "minecraft:item",

--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore_dense.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore_dense.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:uraninite_ore_dense"
             },
             {
               "type": "minecraft:item",

--- a/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore_poor.json
+++ b/forge/src/generated/resources/data/powah/loot_tables/blocks/uraninite_ore_poor.json
@@ -24,7 +24,7 @@
                   }
                 }
               ],
-              "name": "minecraft:air"
+              "name": "powah:uraninite_ore_poor"
             },
             {
               "type": "minecraft:item",


### PR DESCRIPTION
This is intended to fix issue #105.

The ore blocks were setup to drop minecraft:air, presumably for testing(?), and I have changed each ore block to drop the appropriate ore block when mined with silk touch.

I did build the jar and test it after making the changes, works as it should now. 