### PR TITLE
Fixes for some tooltips in Powah's GUI.

### DIFF
--- a/src/main/java/owmii/powah/client/screen/container/FurnatorScreen.java
+++ b/src/main/java/owmii/powah/client/screen/container/FurnatorScreen.java
@@ -57,10 +57,10 @@ public class FurnatorScreen extends AbstractEnergyScreen<FurnatorTile, FurnatorC
                             .translatable("info.lollipop.fe.stored", Util.addCommas(energy.getStored()), Util.numFormat(energy.getCapacity()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.generates").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(this.te.getGeneration())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(this.te.getGeneration()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.max.extract").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(energy.getMaxExtract())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(energy.getMaxExtract()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             gui.renderComponentTooltip(font, list, mouseX, mouseY);
         }

--- a/src/main/java/owmii/powah/client/screen/container/MagmatorScreen.java
+++ b/src/main/java/owmii/powah/client/screen/container/MagmatorScreen.java
@@ -76,10 +76,10 @@ public class MagmatorScreen extends AbstractEnergyScreen<MagmatorTile, MagmatorC
                             .translatable("info.lollipop.fe.stored", Util.addCommas(energy.getStored()), Util.numFormat(energy.getCapacity()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.generates").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(this.te.getGeneration())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(this.te.getGeneration()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.max.extract").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(energy.getMaxExtract())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(energy.getMaxExtract()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             gui.renderComponentTooltip(font, list, mouseX, mouseY);
         }

--- a/src/main/java/owmii/powah/client/screen/container/ReactorScreen.java
+++ b/src/main/java/owmii/powah/client/screen/container/ReactorScreen.java
@@ -92,13 +92,13 @@ public class ReactorScreen extends AbstractEnergyScreen<ReactorTile, ReactorCont
                             .translatable("info.lollipop.fe.stored", Util.addCommas(energy.getStored()), Util.numFormat(energy.getCapacity()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.powah.generation.factor").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(this.te.getGeneration())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(this.te.getGeneration()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.generating").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat((long) this.te.calcProduction()))
-                            .append(Component.translatable("info.lollipop.fe.pet.tick")).withStyle(ChatFormatting.DARK_GRAY)));
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat((long) this.te.calcProduction()))
+                            .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.max.extract").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(energy.getMaxExtract())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(energy.getMaxExtract()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
 
             gui.renderComponentTooltip(font, list, mouseX, mouseY);
@@ -117,8 +117,7 @@ public class ReactorScreen extends AbstractEnergyScreen<ReactorTile, ReactorCont
                     .append(Component.translatable("info.lollipop.mb.stored", String.format("%.0f", this.te.fuel.getTicks()),
                             String.format("%.0f", this.te.fuel.getMax())).withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.using").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(ChatFormatting.GREEN + String.format("%.4f", this.te.calcConsumption()))
-                            .append(Component.translatable("info.lollipop.mb.pet.tick")).withStyle(ChatFormatting.DARK_GRAY)));
+                    .append(Component.translatable("info.lollipop.mb.pet.tick", ChatFormatting.GREEN + String.format("%.4f", this.te.calcConsumption())).withStyle(ChatFormatting.DARK_GRAY)));
             gui.renderComponentTooltip(font, list, mouseX, mouseY);
         }
 

--- a/src/main/java/owmii/powah/client/screen/container/ThermoScreen.java
+++ b/src/main/java/owmii/powah/client/screen/container/ThermoScreen.java
@@ -60,10 +60,10 @@ public class ThermoScreen extends AbstractEnergyScreen<ThermoTile, ThermoContain
                             .translatable("info.lollipop.fe.stored", Util.addCommas(energy.getStored()), Util.numFormat(energy.getCapacity()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.generates").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(this.te.getGeneration())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(this.te.getGeneration()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             list.add(Component.translatable("info.lollipop.max.extract").withStyle(ChatFormatting.GRAY).append(Text.COLON)
-                    .append(Component.literal(Util.numFormat(energy.getMaxExtract())).append(Component.translatable("info.lollipop.fe.pet.tick"))
+                    .append(Component.translatable("info.lollipop.fe.pet.tick", Util.numFormat(energy.getMaxExtract()))
                             .withStyle(ChatFormatting.DARK_GRAY)));
             gui.renderComponentTooltip(font, list, mouseX, mouseY);
         }


### PR DESCRIPTION
Some of the text formatting in tooltips in generator GUI is not working correctly.\
(I found that they are silmilar to #114, but #114 only fixed item tooltips)
### Affected translatable key and GUI
`info.lollipop.fe.pet.tick` in some generator GUI\
`info.lollipop.mb.pet.tick` in reactor GUI
### Before fix
![Before fix: Thermo Generator](https://github.com/Technici4n/Powah/assets/76843407/8a7c30f9-897d-4f02-bf82-1f942c8375c9)
![Before fix: Reactor (FE)](https://github.com/Technici4n/Powah/assets/76843407/24b05184-d8e5-4628-ae6f-c9a8ede8e69d)
![Before fix: Reactor (mB)](https://github.com/Technici4n/Powah/assets/76843407/6f2f8fc3-f39a-4368-85e1-695a285ae852)
### After fix
![After fix: Thermo Generator](https://github.com/Technici4n/Powah/assets/76843407/74363902-eb6d-4f9e-b9ef-318e333c6868)
![After fix: Reactor (FE)](https://github.com/Technici4n/Powah/assets/76843407/6bd206e2-c5bb-4508-ad66-4cad31bca565)
![After fix: Reactor (mB)](https://github.com/Technici4n/Powah/assets/76843407/927e1f14-f9de-497d-9619-dc84b0ef9e4c)