### PR TITLE
Simplify simple blocks by using Block-subclasses equivalent to Vanilla, allowing Mining Gadgets etc. to interact with them

### DIFF
--- a/src/main/java/owmii/powah/block/Blcks.java
+++ b/src/main/java/owmii/powah/block/Blcks.java
@@ -1,7 +1,9 @@
 package owmii.powah.block;
 
 import java.util.function.Supplier;
+import net.minecraft.util.valueproviders.ConstantInt;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.DropExperienceBlock;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import owmii.powah.Powah;
 import owmii.powah.block.cable.CableBlock;
@@ -18,7 +20,6 @@ import owmii.powah.block.reactor.ReactorBlock;
 import owmii.powah.block.solar.SolarBlock;
 import owmii.powah.block.thermo.ThermoBlock;
 import owmii.powah.block.transmitter.PlayerTransmitterBlock;
-import owmii.powah.lib.block.AbstractBlock;
 import owmii.powah.lib.block.Properties;
 import owmii.powah.lib.registry.VarReg;
 
@@ -55,23 +56,25 @@ public class Blcks {
     public static final VarReg<Tier, Block> ENERGY_DISCHARGER = new VarReg<>(DR, "energy_discharger",
             variant -> new EnergyDischargerBlock(Properties.metalNoSolid(2.0f, 20.0f), variant), Tier.getNormalVariants());
     public static final Supplier<Block> ENERGIZED_STEEL = DR.register("energized_steel_block",
-            () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
+            () -> new Block(Properties.metal(2.0f, 20.0f)));
     public static final Supplier<Block> BLAZING_CRYSTAL = DR.register("blazing_crystal_block",
-            () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
-    public static final Supplier<Block> NIOTIC_CRYSTAL = DR.register("niotic_crystal_block", () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
+            () -> new Block(Properties.metal(2.0f, 20.0f)));
+    public static final Supplier<Block> NIOTIC_CRYSTAL = DR.register("niotic_crystal_block", () -> new Block(Properties.metal(2.0f, 20.0f)));
     public static final Supplier<Block> SPIRITED_CRYSTAL = DR.register("spirited_crystal_block",
-            () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
-    public static final Supplier<Block> NITRO_CRYSTAL = DR.register("nitro_crystal_block", () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
-    public static final Supplier<Block> URANINITE = DR.register("uraninite_block", () -> new AbstractBlock(Properties.metal(2.0f, 20.0f)));
+            () -> new Block(Properties.metal(2.0f, 20.0f)));
+    public static final Supplier<Block> NITRO_CRYSTAL = DR.register("nitro_crystal_block", () -> new Block(Properties.metal(2.0f, 20.0f)));
+    public static final Supplier<Block> URANINITE = DR.register("uraninite_block", () -> new Block(Properties.metal(2.0f, 20.0f)));
     public static final Supplier<Block> DEEPSLATE_URANINITE_ORE_POOR = DR.register("deepslate_uraninite_ore_poor",
-            () -> new AbstractBlock(Properties.deepslate()));
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.deepslate()));
     public static final Supplier<Block> DEEPSLATE_URANINITE_ORE = DR.register("deepslate_uraninite_ore",
-            () -> new AbstractBlock(Properties.deepslate()));
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.deepslate()));
     public static final Supplier<Block> DEEPSLATE_URANINITE_ORE_DENSE = DR.register("deepslate_uraninite_ore_dense",
-            () -> new AbstractBlock(Properties.deepslate()));
-    public static final Supplier<Block> URANINITE_ORE_POOR = DR.register("uraninite_ore_poor", () -> new AbstractBlock(Properties.rock(3.0f, 8.0f)));
-    public static final Supplier<Block> URANINITE_ORE = DR.register("uraninite_ore", () -> new AbstractBlock(Properties.rock(3.2f, 8.0f)));
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.deepslate()));
+    public static final Supplier<Block> URANINITE_ORE_POOR = DR.register("uraninite_ore_poor",
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.rock(3.0f, 8.0f)));
+    public static final Supplier<Block> URANINITE_ORE = DR.register("uraninite_ore",
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.rock(3.2f, 8.0f)));
     public static final Supplier<Block> URANINITE_ORE_DENSE = DR.register("uraninite_ore_dense",
-            () -> new AbstractBlock(Properties.rock(4.0f, 8.0f)));
-    public static final Supplier<Block> DRY_ICE = DR.register("dry_ice", () -> new AbstractBlock(Properties.rock(2.0f, 8.0f)));
+            () -> new DropExperienceBlock(ConstantInt.of(0), Properties.rock(4.0f, 8.0f)));
+    public static final Supplier<Block> DRY_ICE = DR.register("dry_ice", () -> new Block(Properties.rock(2.0f, 8.0f)));
 }

--- a/src/main/java/owmii/powah/lib/block/AbstractBlock.java
+++ b/src/main/java/owmii/powah/lib/block/AbstractBlock.java
@@ -41,7 +41,7 @@ import owmii.powah.lib.logistics.inventory.AbstractContainer;
 import owmii.powah.lib.registry.IVariant;
 import owmii.powah.lib.registry.IVariantEntry;
 
-public class AbstractBlock<V extends IVariant, B extends AbstractBlock<V, B>> extends Block implements IVariantEntry<V, B>, IBlock<V, B> {
+public abstract class AbstractBlock<V extends IVariant, B extends AbstractBlock<V, B>> extends Block implements IVariantEntry<V, B>, IBlock<V, B> {
     public static final VoxelShape SEMI_FULL_SHAPE = box(0.01D, 0.01D, 0.01D, 15.99D, 15.99D, 15.99D);
     protected final Map<Direction, VoxelShape> shapes = new HashMap<>();
     protected final V variant;


### PR DESCRIPTION
Fixes #37 