### PR TITLE
Unload entire chunks at once

### DIFF
--- a/common/src/main/java/owmii/powah/block/cable/CableNet.java
+++ b/common/src/main/java/owmii/powah/block/cable/CableNet.java
@@ -1,8 +1,9 @@
 package owmii.powah.block.cable;
 
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -10,14 +11,25 @@ import java.util.Objects;
 import java.util.WeakHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-class CableNet {
-    private static final Map<Level, Map<BlockPos, CableTile>> loadedCables = new WeakHashMap<>();
+public class CableNet {
+    private static final Logger LOG = LoggerFactory.getLogger(CableNet.class);
+
+    // Level -> ChunkPos -> BlockPos -> Tile
+    private static final Map<Level, Long2ObjectMap<Long2ObjectMap<CableTile>>> loadedCables = new WeakHashMap<>();
 
     static void addCable(CableTile cable) {
-        var previousCable = loadedCables.computeIfAbsent(cable.getLevel(), l -> new HashMap<>()).put(cable.getBlockPos().immutable(), cable);
+        var chunkPos = ChunkPos.asLong(cable.getBlockPos());
+        var previousCable = loadedCables.computeIfAbsent(cable.getLevel(), l -> new Long2ObjectOpenHashMap<>())
+                .computeIfAbsent(chunkPos, l -> new Long2ObjectOpenHashMap<>())
+                .put(cable.getBlockPos().asLong(), cable);
 
         if (previousCable != null) {
             throw new RuntimeException("Cable added to position %s, but there was already one there?".formatted(cable.getBlockPos()));
@@ -28,14 +40,32 @@ class CableNet {
 
     static void removeCable(CableTile cable) {
         var levelMap = loadedCables.get(cable.getLevel());
-        if (levelMap.remove(cable.getBlockPos()) != cable) {
+        var chunkPos = ChunkPos.asLong(cable.getBlockPos());
+        var chunkMap = levelMap.get(chunkPos);
+        if (chunkMap == null) {
+            LOG.error("Ignoring to unload cable @ {} since chunk is already gone.", cable.getBlockPos());
+            return;
+        }
+        if (chunkMap.remove(cable.getBlockPos().asLong()) != cable) {
             throw new RuntimeException("Removed wrong cable from position %s".formatted(cable.getBlockPos()));
         }
-        if (levelMap.size() == 0) {
+        if (chunkMap.isEmpty()) {
+            levelMap.remove(chunkPos);
+        }
+        if (levelMap.isEmpty()) {
             loadedCables.remove(cable.getLevel());
         }
 
         updateAdjacentCables(cable);
+    }
+
+    @Nullable
+    private static CableTile getCableAt(Long2ObjectMap<Long2ObjectMap<CableTile>> levelMap, BlockPos pos) {
+        var chunkMap = levelMap.get(ChunkPos.asLong(pos));
+        if (chunkMap == null) {
+            return null;
+        }
+        return chunkMap.get(pos.asLong());
     }
 
     static void updateAdjacentCables(CableTile cable) {
@@ -46,7 +76,7 @@ class CableNet {
 
         for (var direction : Direction.values()) {
             var adjPos = cable.getBlockPos().relative(direction);
-            var adjCable = levelMap.get(adjPos);
+            var adjCable = getCableAt(levelMap, adjPos);
 
             if (adjCable != null && adjCable.net != null) {
                 adjCable.net.cableList.forEach(c -> c.net = null);
@@ -68,7 +98,7 @@ class CableNet {
 
             for (var direction : Direction.values()) {
                 var adjPos = cur.getBlockPos().relative(direction);
-                var adjCable = levelMap.get(adjPos);
+                var adjCable = getCableAt(levelMap, adjPos);
 
                 if (adjCable != null && cables.add(adjCable)) {
                     queue.add(adjCable);
@@ -88,5 +118,25 @@ class CableNet {
 
     CableNet(List<CableTile> cableList) {
         this.cableList = cableList;
+    }
+
+    public static void removeChunk(Level level, ChunkAccess chunk) {
+        var levelMap = loadedCables.get(level);
+        if (levelMap == null) {
+            return; // No cables in this level
+        }
+        var chunkMap = levelMap.remove(chunk.getPos().toLong());
+        if (chunkMap == null) {
+            return; // No cables in this chunk anyway
+        }
+        if (levelMap.isEmpty()) {
+            loadedCables.remove(level); // No more cables in the level, so might as well remove it
+        }
+        for (var cable : chunkMap.values()) {
+            cable.net = null;
+        }
+        for (var cable : chunkMap.values()) {
+            updateAdjacentCables(cable);
+        }
     }
 }

--- a/fabric/src/main/java/owmii/powah/fabric/PowahFabric.java
+++ b/fabric/src/main/java/owmii/powah/fabric/PowahFabric.java
@@ -1,10 +1,13 @@
 package owmii.powah.fabric;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
 import net.fabricmc.fabric.api.event.player.UseBlockCallback;
 import net.minecraft.SharedConstants;
 import net.minecraft.world.InteractionResult;
 import owmii.powah.Powah;
+import owmii.powah.block.cable.CableNet;
 import owmii.powah.lib.item.ItemBase;
 import owmii.powah.lib.util.Wrench;
 
@@ -18,6 +21,9 @@ public class PowahFabric implements ModInitializer {
         Powah.init();
 
         SharedConstants.CHECK_DATA_FIXER_SCHEMA = checkDataFixer;
+
+        ServerChunkEvents.CHUNK_UNLOAD.register(CableNet::removeChunk);
+        ClientChunkEvents.CHUNK_UNLOAD.register(CableNet::removeChunk);
 
         UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
             if (Wrench.removeWithWrench(player, world, hand, hitResult)) {

--- a/forge/src/main/java/owmii/powah/forge/PowahForge.java
+++ b/forge/src/main/java/owmii/powah/forge/PowahForge.java
@@ -2,14 +2,17 @@ package owmii.powah.forge;
 
 import dev.architectury.platform.forge.EventBuses;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.level.Level;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.level.ChunkEvent;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.fml.loading.FMLEnvironment;
 import owmii.powah.Powah;
+import owmii.powah.block.cable.CableNet;
 import owmii.powah.forge.compat.curios.CuriosCompat;
 import owmii.powah.forge.data.DataEvents;
 import owmii.powah.lib.util.Wrench;
@@ -29,6 +32,11 @@ public class PowahForge {
             if (Wrench.removeWithWrench(event.getEntity(), event.getLevel(), event.getHand(), event.getHitVec())) {
                 event.setCanceled(true);
                 event.setCancellationResult(InteractionResult.sidedSuccess(event.getLevel().isClientSide));
+            }
+        });
+        MinecraftForge.EVENT_BUS.addListener((ChunkEvent.Unload event) -> {
+            if (event.getLevel() instanceof Level level) {
+                CableNet.removeChunk(level, event.getChunk());
             }
         });
 


### PR DESCRIPTION
This intends to fix:

```
java.lang.RuntimeException: Cable added to position BlockPos{x=-1255, y=111, z=-113}, but there was already one there?
at owmii.powah.block.cable.CableNet.addCable(CableNet.java:23) ~[Powah-5.0.5.jar%23801!/:?] {re:classloading}
at owmii.powah.block.cable.CableTile.m_6339_(CableTile.java:44) ~[Powah-5.0.5.jar%23801!/:?] {re:classloading}
at net.minecraft.world.level.chunk.LevelChunk.m_142169_(LevelChunk.java:362) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:corgilib.mixins.json:chunk.MixinLevelChunk,pl:mixin:APP:lootr.mixins.json:MixinLevelChunk,pl:mixin:APP:gtceu.mixins.json:ChunkMixin,pl:mixin:APP:moonlight-common.mixins.json:LevelChunkMixin,pl:mixin:A}
at net.minecraft.world.level.chunk.storage.ChunkSerializer.m_196900_(ChunkSerializer.java:404) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:corgilib.mixins.json:chunk.MixinChunkSerializer,pl:mixin:APP:railways-common.mixins.json:ChunkSerializerMixin,pl:mixin:APP:architectury.mixins.json:MixinChunkSerializer,pl:mixin:A}
at net.minecraft.world.level.chunk.LevelChunk.m_62952_(LevelChunk.java:438) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:APP:corgilib.mixins.json:chunk.MixinLevelChunk,pl:mixin:APP:lootr.mixins.json:MixinLevelChunk,pl:mixin:APP:gtceu.mixins.json:ChunkMixin,pl:mixin:APP:moonlight-common.mixins.json:LevelChunkMixin,pl:mixin:A}
at net.minecraft.server.level.ChunkMap.mixinextras$bridge$m_62952_$152(ChunkMap.java) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.level.ChunkMap.wrapOperation$zdf000$setCurrentLoadingThenPostLoad(ChunkMap.java:1905) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at net.minecraft.server.level.ChunkMap.m_214854_(ChunkMap.java:715) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at com.mojang.datafixers.util.Either.lambda$mapLeft$0(Either.java:162) ~[datafixerupper-6.0.8.jar%2377!/:?] {re:mixin}
at com.mojang.datafixers.util.Either$Left.map(Either.java:38) ~[datafixerupper-6.0.8.jar%2377!/:?] {}
at com.mojang.datafixers.util.Either.mapLeft(Either.java:162) ~[datafixerupper-6.0.8.jar%2377!/:?] {re:mixin}
at net.minecraft.server.level.ChunkMap.m_287044_(ChunkMap.java:699) ~[server-1.20.1-20230612.114412-srg.jar%23917!/:?] {re:mixin,pl:accesstransformer:B,re:classloading,pl:accesstransformer:B,pl:mixin:A}
at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:646) ~[?:?] {}
at java.util.concurrent.CompletableFuture$Completion.run(CompletableFuture.java:482) ~[?:?] {}

```