### PR TITLE
Add lava again as a heat source

### DIFF
--- a/src/generated/resources/data/powah/data_maps/block/heat_source.json
+++ b/src/generated/resources/data/powah/data_maps/block/heat_source.json
@@ -1,5 +1,8 @@
 {
   "values": {
+    "minecraft:lava": {
+      "temperature": 1000
+    },
     "minecraft:magma_block": {
       "temperature": 800
     },


### PR DESCRIPTION
During the data_maps transition lava was removed as a heat source, leading to Thermo Generators not working over a block of lava.

Fix #167.