### PR TITLE
Add fluid heat source registration support

### DIFF
--- a/common/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/common/src/main/java/owmii/powah/api/PowahAPI.java
@@ -6,8 +6,10 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluid;
 import org.apache.commons.lang3.tuple.Pair;
+import owmii.powah.Powah;
 
 public class PowahAPI {
 
@@ -67,6 +69,34 @@ public class PowahAPI {
      **/
     public static void registerHeatSource(ResourceLocation block, int heat) {
         HEAT_SOURCES.put(block, heat);
+    }
+
+    /**
+     * Register a fluid as a heat source by resolving its fluid block via BuiltInRegistries.
+     *
+     * @param fluidId The fluid's ResourceLocation.
+     * @param heat    The amount of heat it provides.
+     */
+    public static void registerFluidHeatSource(ResourceLocation fluidId, int heat) {
+        Fluid fluid = BuiltInRegistries.FLUID.get(fluidId);
+        if (fluid == null) {
+            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' not found in registry", fluidId);
+            return;
+        }
+
+        Block fluidBlock = fluid.defaultFluidState().createLegacyBlock().getBlock();
+        if (fluidBlock == Blocks.AIR) {
+            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' has no associated block", fluidId);
+            return;
+        }
+
+        ResourceLocation blockId = BuiltInRegistries.BLOCK.getKey(fluidBlock);
+        if (blockId == null) {
+            Powah.LOGGER.warn("[PowahAPI] Block for fluid '{}' not found in registry", fluidId);
+            return;
+        }
+
+        registerHeatSource(blockId, heat);
     }
 
     /**


### PR DESCRIPTION
### Summary

This PR introduces a new method to `PowahAPI` that allows registering fluid-based heat sources by resolving their corresponding fluid block via the registry. This makes it easier to add compatibility with fluids from other mods like Mekanism.

### Additions

- `PowahAPI.registerFluidHeatSource(ResourceLocation fluidId, int heat)`
    - Looks up the fluid from `BuiltInRegistries.FLUID`
    - Retrieves the corresponding fluid block (via `defaultFluidState().createLegacyBlock()`)
    - Registers it as a heat source using the already existing `registerHeatSource` method

### Motivation

Currently, Powah does not provide any way to register fluids as heat sources — only blocks are supported. This makes it impossible to integrate external modded fluids (like those from Mekanism) into the heat system without modifying the codebase directly.

This PR adds a clean utility method to the existing PowahAPI, enabling heat source registration from fluid IDs (instead of just blocks), which was previously not possible.

### Example usage (with KubeJS)

```js
// KubeJS - startup_scripts/powah_api.js
StartupEvents.postInit(event => {
  const PowahAPI = Java.loadClass("owmii.powah.api.PowahAPI");
  const ResourceLocation = Java.loadClass("net.minecraft.resources.ResourceLocation");

  PowahAPI.registerFluidHeatSource(new ResourceLocation("mekanismgenerators:fusion_fuel"), 1500);
});
