### PR TITLE
Add warning log when registerHeatSource is called with invalid or AIR block

### DIFF
--- a/common/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/common/src/main/java/owmii/powah/api/PowahAPI.java
@@ -70,7 +70,7 @@ public class PowahAPI {
     public static void registerHeatSource(ResourceLocation block, int heat) {
         Block resolved = BuiltInRegistries.BLOCK.get(block);
 
-        if (resolved == null || resolved == Blocks.AIR) {
+        if (resolved == Blocks.AIR) {
             Powah.LOGGER.warn("PowahAPI: Skipped heat source registration — block [{}] does not exist or is AIR", block);
             return;
         }

--- a/common/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/common/src/main/java/owmii/powah/api/PowahAPI.java
@@ -68,6 +68,13 @@ public class PowahAPI {
      * @param heat:  the heat of the block.
      **/
     public static void registerHeatSource(ResourceLocation block, int heat) {
+        Block resolved = BuiltInRegistries.BLOCK.get(block);
+
+        if (resolved == null || resolved == Blocks.AIR) {
+            Powah.LOGGER.warn("PowahAPI: Skipped heat source registration — block [{}] does not exist or is AIR", block);
+            return;
+        }
+
         HEAT_SOURCES.put(block, heat);
     }
 

--- a/common/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/common/src/main/java/owmii/powah/api/PowahAPI.java
@@ -6,8 +6,10 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluid;
 import org.apache.commons.lang3.tuple.Pair;
+import owmii.powah.Powah;
 
 public class PowahAPI {
 
@@ -67,6 +69,34 @@ public class PowahAPI {
      **/
     public static void registerHeatSource(ResourceLocation block, int heat) {
         HEAT_SOURCES.put(block, heat);
+    }
+
+    /**
+     * Register a fluid as a heat source by resolving its fluid block via BuiltInRegistries.
+     *
+     * @param fluidId The fluid's ResourceLocation.
+     * @param heat    The amount of heat it provides.
+     */
+    public static void registerFluidHeatSource(ResourceLocation fluidId, int heat) {
+        Fluid fluid = BuiltInRegistries.FLUID.get(fluidId);
+        if (fluid == null) {
+            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' not found in registry", fluidId);
+            return;
+        }
+
+        Block fluidBlock = fluid.defaultFluidState().createLegacyBlock().getBlock();
+        if (fluidBlock == Blocks.AIR) {
+            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' has no associated block", fluidId);
+            return;
+        }
+
+        ResourceLocation blockId = BuiltInRegistries.BLOCK.getKey(fluidBlock);
+        if (blockId == null) {
+            Powah.LOGGER.warn("[PowahAPI] Block for fluid '{}' not found in registry", fluidId);
+            return;
+        }
+
+        registerHeatSource(blockId, heat);
     }
 
     /**

--- a/common/src/main/java/owmii/powah/api/PowahAPI.java
+++ b/common/src/main/java/owmii/powah/api/PowahAPI.java
@@ -79,34 +79,6 @@ public class PowahAPI {
     }
 
     /**
-     * Register a fluid as a heat source by resolving its fluid block via BuiltInRegistries.
-     *
-     * @param fluidId The fluid's ResourceLocation.
-     * @param heat    The amount of heat it provides.
-     */
-    public static void registerFluidHeatSource(ResourceLocation fluidId, int heat) {
-        Fluid fluid = BuiltInRegistries.FLUID.get(fluidId);
-        if (fluid == null) {
-            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' not found in registry", fluidId);
-            return;
-        }
-
-        Block fluidBlock = fluid.defaultFluidState().createLegacyBlock().getBlock();
-        if (fluidBlock == Blocks.AIR) {
-            Powah.LOGGER.warn("[PowahAPI] Fluid '{}' has no associated block", fluidId);
-            return;
-        }
-
-        ResourceLocation blockId = BuiltInRegistries.BLOCK.getKey(fluidBlock);
-        if (blockId == null) {
-            Powah.LOGGER.warn("[PowahAPI] Block for fluid '{}' not found in registry", fluidId);
-            return;
-        }
-
-        registerHeatSource(blockId, heat);
-    }
-
-    /**
      * the heat of the heat source block/fluid block.
      *
      * @param block: the block used as heat source.


### PR DESCRIPTION
Adds a warning log in `PowahAPI.registerHeatSource(...)` when the block ID is missing or resolves to AIR.

This prevents silent failures and helps identify misconfigurations more easily, especially when registering fluid blocks from other mods.