### PR TITLE
Fix Thermo tooltip not resetting to 0 and coolant formula

### DIFF
--- a/src/generated/resources/data/powah/data_maps/fluid/fluid_coolant.json
+++ b/src/generated/resources/data/powah/data_maps/fluid/fluid_coolant.json
@@ -1,7 +1,7 @@
 {
   "values": {
     "#c:water": {
-      "temperature": 1
+      "temperature": 0
     }
   }
 }

--- a/src/main/java/owmii/powah/api/FluidCoolantConfig.java
+++ b/src/main/java/owmii/powah/api/FluidCoolantConfig.java
@@ -10,9 +10,18 @@ import owmii.powah.Powah;
 public record FluidCoolantConfig(int temperature) {
     public static final Codec<FluidCoolantConfig> CODEC = RecordCodecBuilder.create(builder -> builder
             .group(
-                    Codec.INT.fieldOf("temperature").forGetter(FluidCoolantConfig::temperature))
+                    Codec.intRange(-273, 0).fieldOf("temperature").forGetter(FluidCoolantConfig::temperature))
             .apply(builder, FluidCoolantConfig::new));
     public static final DataMapType<Fluid, FluidCoolantConfig> DATA_MAP_TYPE = DataMapType.builder(Powah.id("fluid_coolant"), Registries.FLUID, CODEC)
             .synced(CODEC, true)
             .build();
+
+    public FluidCoolantConfig {
+        if (temperature > 0) {
+            throw new IllegalArgumentException("Temperature must be less than or equal to 0.");
+        }
+        if (temperature < -273) {
+            throw new IllegalArgumentException("Temperature must be greater than or equal to -273.");
+        }
+    }
 }

--- a/src/main/java/owmii/powah/block/thermo/ThermoTile.java
+++ b/src/main/java/owmii/powah/block/thermo/ThermoTile.java
@@ -56,12 +56,24 @@ public class ThermoTile extends AbstractEnergyProvider<ThermoBlock> implements I
                 BlockState state = world.getBlockState(heatPos);
                 int heat = PowahAPI.getHeatSource(state);
                 if (!this.energy.isFull() && heat != 0) {
-                    this.generating = (int) ((heat * Math.max(1D, (1D + fluidCooling.getAsInt()) / 2D) * getGeneration()) / 1000.0D);
+                    double heatRatio = heat / 1000.0;
+                    // The formula I want is:
+                    // (water) 0 °C -> ratio of 1
+                    // (water) -10 °C -> ratio of 5
+                    // (water) -20 °C -> ratio of 10
+                    // and so on...
+                    // So we do -temperature/2 with a max to handle the 0 °C case
+                    double coolantRatio = Math.max(1D, -fluidCooling.getAsInt() / 2D);
+                    this.generating = (int) (heatRatio * coolantRatio * getGeneration());
                     this.energy.produce(this.generating);
                     if (world.getGameTime() % 40 == 0L) {
                         this.tank.drain(1, IFluidHandler.FluidAction.EXECUTE);
                     }
+                } else {
+                    this.generating = 0;
                 }
+            } else {
+                this.generating = 0;
             }
         }
 

--- a/src/main/java/owmii/powah/data/PowahDataMapProvider.java
+++ b/src/main/java/owmii/powah/data/PowahDataMapProvider.java
@@ -32,7 +32,7 @@ class PowahDataMapProvider extends DataMapProvider {
                 .add(Itms.URANINITE, new ReactorFuel(100, 700), false)
                 .build();
         builder(FluidCoolantConfig.DATA_MAP_TYPE)
-                .add(Tags.Fluids.WATER, new FluidCoolantConfig(1), false)
+                .add(Tags.Fluids.WATER, new FluidCoolantConfig(0), false)
                 .build();
 
         builder(SolidCoolantConfig.DATA_MAP_TYPE)


### PR DESCRIPTION
Coolant temperatures $T$ can now only be in the $[-273, 0]$ range. The output of the Thermo generator is multiplied by $-\frac T2$ (or 1 if it would be lower than 1).