### PR TITLE
Optimize checkRedstone to skip signal check when mode is IGNORE

### DIFF
--- a/common/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
+++ b/common/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
@@ -208,9 +208,15 @@ public class AbstractTileEntity<V extends IVariant, B extends AbstractBlock<V, B
     }
 
     public boolean checkRedstone() {
+        Redstone redstoneMode = getRedstoneMode();
+
+        // avoid checking redstone if mode is IGNORE
+        // getBestNeighborSignal is relatively expensive and should not be called if not needed
+        if (Redstone.IGNORE.equals(redstoneMode)) return true;
+
         boolean power = this.level != null && this.level.getBestNeighborSignal(this.worldPosition) > 0;
-        return Redstone.IGNORE.equals(getRedstoneMode()) || power && Redstone.ON.equals(getRedstoneMode())
-                || !power && Redstone.OFF.equals(getRedstoneMode());
+        return  power && Redstone.ON.equals(redstoneMode)
+                || !power && Redstone.OFF.equals(redstoneMode);
     }
 
     public void sync() {

--- a/common/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
+++ b/common/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
@@ -212,10 +212,11 @@ public class AbstractTileEntity<V extends IVariant, B extends AbstractBlock<V, B
 
         // avoid checking redstone if mode is IGNORE
         // getBestNeighborSignal is relatively expensive and should not be called if not needed
-        if (Redstone.IGNORE.equals(redstoneMode)) return true;
+        if (Redstone.IGNORE.equals(redstoneMode))
+            return true;
 
         boolean power = this.level != null && this.level.getBestNeighborSignal(this.worldPosition) > 0;
-        return  power && Redstone.ON.equals(redstoneMode)
+        return power && Redstone.ON.equals(redstoneMode)
                 || !power && Redstone.OFF.equals(redstoneMode);
     }
 


### PR DESCRIPTION
The redstone check by itself looks innocent but in agreggentum having multiple blocks do this check gets very expensive. Found this looking at Spark flamegraphs. I'm guessing there's other areas for improvements but for now this is the biggest cause for unnecessary work.

I based this on 1.20.1 as that is what I am running but the changes for 1.21.1 are identical. 