### PR TITLE
Fix cable block state connection logic

### DIFF
--- a/src/main/java/owmii/powah/block/cable/CableBlock.java
+++ b/src/main/java/owmii/powah/block/cable/CableBlock.java
@@ -124,15 +124,15 @@ public class CableBlock extends AbstractEnergyBlock<CableConfig, CableBlock> imp
 
     private BlockState createCableState(Level world, BlockPos pos) {
         final BlockState state = defaultBlockState();
-        boolean[] north = canAttach(state, world, pos, Direction.NORTH);
-        boolean[] south = canAttach(state, world, pos, Direction.SOUTH);
-        boolean[] west = canAttach(state, world, pos, Direction.WEST);
-        boolean[] east = canAttach(state, world, pos, Direction.EAST);
-        boolean[] up = canAttach(state, world, pos, Direction.UP);
-        boolean[] down = canAttach(state, world, pos, Direction.DOWN);
+        boolean north = canAttach(world, pos, Direction.NORTH);
+        boolean south = canAttach(world, pos, Direction.SOUTH);
+        boolean west = canAttach(world, pos, Direction.WEST);
+        boolean east = canAttach(world, pos, Direction.EAST);
+        boolean up = canAttach(world, pos, Direction.UP);
+        boolean down = canAttach(world, pos, Direction.DOWN);
         FluidState fluidState = world.getFluidState(pos);
-        return state.setValue(NORTH, north[0] && !north[1]).setValue(SOUTH, south[0] && !south[1]).setValue(WEST, west[0] && !west[1])
-                .setValue(EAST, east[0] && !east[1]).setValue(UP, up[0] && !up[1]).setValue(DOWN, down[0] && !down[1])
+        return state.setValue(NORTH, north).setValue(SOUTH, south).setValue(WEST, west)
+                .setValue(EAST, east).setValue(UP, up).setValue(DOWN, down)
                 .setValue(BlockStateProperties.WATERLOGGED, fluidState.getType() == Fluids.WATER);
     }
 
@@ -176,9 +176,8 @@ public class CableBlock extends AbstractEnergyBlock<CableConfig, CableBlock> imp
         super.onPlace(state, world, pos, oldState, isMoving);
     }
 
-    public boolean[] canAttach(BlockState state, Level world, BlockPos pos, Direction direction) {
-        return new boolean[] { world.getBlockState(pos.relative(direction)).getBlock() == this || canConnectEnergy(world, pos, direction),
-                canConnectEnergy(world, pos, direction) };
+    public boolean canAttach(Level world, BlockPos pos, Direction direction) {
+        return world.getBlockState(pos.relative(direction)).getBlock() == this || canConnectEnergy(world, pos, direction);
     }
 
     public boolean canConnectEnergy(Level world, BlockPos pos, Direction direction) {


### PR DESCRIPTION
This pull request fixes the connection logic inside the `CableBlock`.

Connections are determined by the block's `BlockState`. Each direction has a boolean property that is evaluated when the block is placed or when a neighbor changes. This happens inside the `canAttach` logic.

Previously, the `canAttach` logic constructed a boolean array. The first index stored whether the neighbor block is a `CableBlock` as well *or* whether it exposes an energy capability. The second index used the same check to determine whether the neighbor exposes an energy capability.

For all `CableBlock`s, this always resulted in `[true, false]`. For all non-energy-cap-exposing blocks, this resulted in `[false, false]`. For energy-cap-exposing blocks, this resulted in `[true, true]`. But because the `BlockState` values are set via `result[0] && !result[1]`, this can only ever be true for another `CableBlock`, making the check useless for energy-cap-exposing blocks.

The pull request simplifies the logic to either check for a `CableBlock` or for an exposed energy capability.

This also results in some performance improvements. Looking at the [`CableBlock#getShape`](https://github.com/Technici4n/Powah/blob/1.21.1/src/main/java/owmii/powah/block/cable/CableBlock.java#L73-L91) method, it checks for the `BlockState` first. This is more efficient than checking whether the block can accept energy. Previously, this check always failed except for `CableBlock`s. Now, this works properly.

I have no idea why this logic was in place. Semantically, this makes no sense because it can never be `true && false` if both sides of the logic use the same method.

Before
<img width="1670" height="762" alt="image" src="https://github.com/user-attachments/assets/6077cc4a-94e4-42b1-a3fe-7d6fed8e649b" />

After
<img width="1403" height="574" alt="image" src="https://github.com/user-attachments/assets/d789d63a-18f7-4361-9971-9d9d5c912e4e" />
