### PR TITLE
Implement Clearable on AbstractTileEntity

### DIFF
--- a/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
+++ b/src/main/java/owmii/powah/lib/block/AbstractTileEntity.java
@@ -5,6 +5,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Clearable;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
@@ -21,7 +22,8 @@ import owmii.powah.lib.logistics.inventory.Inventory;
 import owmii.powah.lib.registry.IVariant;
 
 @SuppressWarnings("unchecked")
-public class AbstractTileEntity<V extends IVariant, B extends AbstractBlock<V, B>> extends BlockEntity implements IBlockEntity, IRedstoneInteract {
+public class AbstractTileEntity<V extends IVariant, B extends AbstractBlock<V, B>> extends BlockEntity
+        implements IBlockEntity, IRedstoneInteract, Clearable {
     /**
      * Used when this is instance of {@link IInventoryHolder}
      **/
@@ -158,6 +160,11 @@ public class AbstractTileEntity<V extends IVariant, B extends AbstractBlock<V, B
         if (storedState != null) {
             readStorable(storedState.copyTag(), level.registryAccess());
         }
+    }
+
+    @Override
+    public void clearContent() {
+        this.inv.clear();
     }
 
     @Override


### PR DESCRIPTION
Patches the dupe glitch with Create: Aeronautics Swivel Bearing

## Before

[before furnator.webm](https://github.com/user-attachments/assets/5972e06a-781a-4e4a-8d6d-51cc85801dfd)

## After

[after furnator.webm](https://github.com/user-attachments/assets/156cd71e-9858-476c-a388-2862ce582d8c)
